### PR TITLE
Extending the plugin to function as a resources provider as per the resources API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SignalK Active Captain plugin
 
-Publishes points of interest (POI) from ActiveCaptain under `pointsOfInterest.activeCaptain.{id}` as well as a note resource. 
 
+## Publishes points of interest (POI) from ActiveCaptain under `pointsOfInterest.activeCaptain.{id}`.
 Here is an example:
 
 ```
@@ -14,6 +14,46 @@ Here is an example:
   "type": "Marina",
   "notes": "",
   "url": "https://activecaptain.garmin.com/en-US/pois/17411"
+}
+```
+
+## Optionally publishes the same POIs as note resources accessible through the resources API.
+Here is an example:
+```
+> curl -XGET "localhost:3000/signalk/v2/api/resources/notes/68093" | jq
+{
+  "name": "Lock #1 - Canal du Centre",
+  "description": "Note 1 - Pk 48.8\rVertical drop 2.34m\n",
+  "position": {
+    "latitude": 46.75516272316218,
+    "longitude": 4.505402798320954
+  },
+  "group": "Lock",
+  "url": "https://activecaptain.garmin.com/en-US/pois/68093"
+}
+```
+
+## Optionally publishes the same POIs as custom ac_* resources with the raw payload from ActiveCaptain, accessible through the resources API. 
+Here is an example:
+```
+curl -XGET "localhost:3000/signalk/v2/api/resources/ac_Lock/68093" | jq
+{
+  "pointOfInterest": {
+    "dateLastModified": "2014-08-07T11:34:21",
+    "id": 68093,
+    "mapLocation": {
+      "latitude": 46.75516272316218,
+      "longitude": 4.505402798320954
+    },
+    "name": "Lock #1 - Canal du Centre",
+    "poiType": "Lock",
+    "notes": [
+      {
+        "field": "PoiNotes",
+        "value": "Pk 48.8\rVertical drop 2.34m"
+      }
+    ]
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# NOAA Observations
+# SignalK Active Captain plugin
 
-Publishes points of interest (POI) from ActiveCaptain under `pointsOfInterest.activeCaptain.{id}`. Here is an example:
+Publishes points of interest (POI) from ActiveCaptain under `pointsOfInterest.activeCaptain.{id}` as well as a note resource. 
+
+Here is an example:
 
 ```
 {

--- a/index.js
+++ b/index.js
@@ -13,9 +13,6 @@
  * limitations under the License.
  */
 
-//import { ResourceProvider } from '@signalk/server-api'
-// const { ResourceProvider } = require('@signalk/server-api');
-
 const request = require('request');
 const poiKey = 'pointsOfInterest.activeCaptain';
 const userAgent = 'Signal K ActiveCaptain Plugin';
@@ -45,7 +42,7 @@ module.exports = function(app) {
     if(options.noteResources) {
       registerAsNoteResourcesProvider();
     }
-    if(options.garminResources) {
+    if(options.customResources) {
       registerAsCustomResourcesProviders();
     }
   }
@@ -62,9 +59,9 @@ module.exports = function(app) {
         title: 'Publish ActiveCaptain points of interest as note resources using the resource API',
         default: true
       },
-      garminResources: {
+      customResources: {
         type: 'boolean',
-        title: 'Publish ActiveCaptain points of interest as custom Garmin resources using the resource API (ac_Unknown, ac_Anchorage, ac_Hazard, ac_Marina, ac_LocalKnowledge, ac_Navigational, ac_BoatRamp, ac_Business, ac_Inlet, ac_Bridge, ac_Lock, ac_Dam, ac_Ferry, ac_Airport)',
+        title: 'Publish ActiveCaptain points of interest as custom resources using the resource API (ac_Unknown, ac_Anchorage, ac_Hazard, ac_Marina, ac_LocalKnowledge, ac_Navigational, ac_BoatRamp, ac_Business, ac_Inlet, ac_Bridge, ac_Lock, ac_Dam, ac_Ferry, ac_Airport)',
         default: false
       } 
     }
@@ -251,8 +248,6 @@ module.exports = function(app) {
           shortNotes = '';
           longNotes = '';
         }
-
-        // app.debug(`Fetched POI data ${poi.id}: ${JSON.stringify(data)}`);
 
         pois[poi.id] = {
           id: poi.id,

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ module.exports = function(app) {
     name: "ActiveCaptain",
     description: "Publishes ActiveCaptain Points of Interest" 
   };
+
   var pois = {};
 
   plugin.start = function(options) {
@@ -41,21 +42,47 @@ module.exports = function(app) {
     }, checkEveryNMinutes * 60 * 1000);
 
     // Register as a resource provider
+    if(options.noteResources) {
+      registerAsNoteResourcesProvider();
+    }
+    if(options.garminResources) {
+      registerAsCustomGarminResourcesProvider();
+    }
+  }
+
+  plugin.stop =  function() {
+  };
+
+  plugin.schema = {
+    type: 'object',
+    required: [],
+    properties: {
+      noteResources: {
+        type: 'boolean',
+        title: 'Publish ActiveCaptain points of interest as note resources using the resource API',
+        default: true
+      },
+      garminResources: {
+        type: 'boolean',
+        title: 'Publish ActiveCaptain points of interest as custom Garmin resources using the resource API (ac_Unknown, ac_Anchorage, ac_Hazard, ac_Marina, ac_LocalKnowledge, ac_Navigational, ac_BoatRamp, ac_Business, ac_Inlet, ac_Bridge, ac_Lock, ac_Dam, ac_Ferry, ac_Airport)',
+        default: false
+      } 
+    }
+  }
+
+  function registerAsNoteResourcesProvider() {
     try {
       app.registerResourceProvider({
-        type: 'waypoints',
+        type: 'notes',
         methods: {
           listResources: (params) => { 
-            app.debug(`List`)
+            app.debug(`Incoming request to list note resources`)
             return new Promise((resolve, reject) => {
               reject(new Error('Still testing'))
             })
           },
           getResource: (id, property) => { 
-            app.debug(`Get`)
-            return new Promise((resolve, reject) => {
-              reject(new Error('Still testing'))
-            })
+            throw(new Error('Not implemented!'))
           },
           setResource: (id, value) => { 
             throw(new Error('Not implemented!'))
@@ -70,18 +97,398 @@ module.exports = function(app) {
     }
   }
 
-  plugin.stop =  function() {
-  };
+  function registerAsCustomGarminResourcesProvider() {
+    registerAsCustomerGarminUnknownResourcesProvider();
+    registerAsCustomerGarminAnchorageResourcesProvider();
+    registerAsCustomerGarminHazardResourcesProvider();
+    registerAsCustomerGarminMarinaResourcesProvider();
+    registerAsCustomerGarminLocalKnowledgeResourcesProvider();
+    registerAsCustomerGarminNavigationalResourcesProvider();
+    registerAsCustomerGarminBoatRampResourcesProvider();
+    registerAsCustomerGarminBusinessResourcesProvider();
+    registerAsCustomerGarminInletResourcesProvider();
+    registerAsCustomerGarminBridgeResourcesProvider();
+    registerAsCustomerGarminLockResourcesProvider();
+    registerAsCustomerGarminDamResourcesProvider();
+    registerAsCustomerGarminFerryResourcesProvider();
+    registerAsCustomerGarminAirportResourcesProvider();
+  }
 
-  plugin.schema = {
-    type: 'object',
-    required: [],
-    properties: {
-      resources: {
-        type: 'boolean',
-        title: 'Also publish activecaptain points of interest as note resources using the resource API',
-        default: true
-      }
+  function registerAsCustomerGarminUnknownResourcesProvider() {
+    try {
+      app.registerResourceProvider({
+        type: 'ac_Unknown',
+        methods: {
+          listResources: (params) => { 
+            app.debug(`Incoming request to list note resources`)
+            return new Promise((resolve, reject) => {
+              reject(new Error('Still testing'))
+            })
+          },
+          getResource: (id, property) => { 
+            throw(new Error('Not implemented!'))
+          },
+          setResource: (id, value) => { 
+            throw(new Error('Not implemented!'))
+          },
+          deleteResource: (id) => { 
+            throw(new Error('Not implemented!'))
+          }
+        }
+      });
+    } catch (error) {
+      app.debug(`Cannot register as a resource provider ${error}`);
+    }
+  }
+
+  function registerAsCustomerGarminAnchorageResourcesProvider() {
+    try {
+      app.registerResourceProvider({
+        type: 'ac_Anchorage',
+        methods: {
+          listResources: (params) => { 
+            app.debug(`Incoming request to list note resources`)
+            return new Promise((resolve, reject) => {
+              reject(new Error('Still testing'))
+            })
+          },
+          getResource: (id, property) => { 
+            throw(new Error('Not implemented!'))
+          },
+          setResource: (id, value) => { 
+            throw(new Error('Not implemented!'))
+          },
+          deleteResource: (id) => { 
+            throw(new Error('Not implemented!'))
+          }
+        }
+      });
+    } catch (error) {
+      app.debug(`Cannot register as a resource provider ${error}`);
+    }
+  }
+
+  function registerAsCustomerGarminHazardResourcesProvider() {
+    try {
+      app.registerResourceProvider({
+        type: 'ac_Hazard',
+        methods: {
+          listResources: (params) => { 
+            app.debug(`Incoming request to list note resources`)
+            return new Promise((resolve, reject) => {
+              reject(new Error('Still testing'))
+            })
+          },
+          getResource: (id, property) => { 
+            throw(new Error('Not implemented!'))
+          },
+          setResource: (id, value) => { 
+            throw(new Error('Not implemented!'))
+          },
+          deleteResource: (id) => { 
+            throw(new Error('Not implemented!'))
+          }
+        }
+      });
+    } catch (error) {
+      app.debug(`Cannot register as a resource provider ${error}`);
+    }
+  }
+
+  function registerAsCustomerGarminMarinaResourcesProvider() {
+    try {
+      app.registerResourceProvider({
+        type: 'ac_Marina',
+        methods: {
+          listResources: (params) => { 
+            app.debug(`Incoming request to list note resources`)
+            return new Promise((resolve, reject) => {
+              reject(new Error('Still testing'))
+            })
+          },
+          getResource: (id, property) => { 
+            throw(new Error('Not implemented!'))
+          },
+          setResource: (id, value) => { 
+            throw(new Error('Not implemented!'))
+          },
+          deleteResource: (id) => { 
+            throw(new Error('Not implemented!'))
+          }
+        }
+      });
+    } catch (error) {
+      app.debug(`Cannot register as a resource provider ${error}`);
+    }
+  }
+
+  function registerAsCustomerGarminLocalKnowledgeResourcesProvider() {
+    try {
+      app.registerResourceProvider({
+        type: 'ac_LocalKnowledge',
+        methods: {
+          listResources: (params) => { 
+            app.debug(`Incoming request to list note resources`)
+            return new Promise((resolve, reject) => {
+              reject(new Error('Still testing'))
+            })
+          },
+          getResource: (id, property) => { 
+            throw(new Error('Not implemented!'))
+          },
+          setResource: (id, value) => { 
+            throw(new Error('Not implemented!'))
+          },
+          deleteResource: (id) => { 
+            throw(new Error('Not implemented!'))
+          }
+        }
+      });
+    } catch (error) {
+      app.debug(`Cannot register as a resource provider ${error}`);
+    }
+  }
+
+  function registerAsCustomerGarminNavigationalResourcesProvider() {
+    try {
+      app.registerResourceProvider({
+        type: 'ac_Navigational',
+        methods: {
+          listResources: (params) => { 
+            app.debug(`Incoming request to list note resources`)
+            return new Promise((resolve, reject) => {
+              reject(new Error('Still testing'))
+            })
+          },
+          getResource: (id, property) => { 
+            throw(new Error('Not implemented!'))
+          },
+          setResource: (id, value) => { 
+            throw(new Error('Not implemented!'))
+          },
+          deleteResource: (id) => { 
+            throw(new Error('Not implemented!'))
+          }
+        }
+      });
+    } catch (error) {
+      app.debug(`Cannot register as a resource provider ${error}`);
+    }
+  }
+
+  function registerAsCustomerGarminBoatRampResourcesProvider() {
+    try {
+      app.registerResourceProvider({
+        type: 'sc_BoatRamp',
+        methods: {
+          listResources: (params) => { 
+            app.debug(`Incoming request to list note resources`)
+            return new Promise((resolve, reject) => {
+              reject(new Error('Still testing'))
+            })
+          },
+          getResource: (id, property) => { 
+            throw(new Error('Not implemented!'))
+          },
+          setResource: (id, value) => { 
+            throw(new Error('Not implemented!'))
+          },
+          deleteResource: (id) => { 
+            throw(new Error('Not implemented!'))
+          }
+        }
+      });
+    } catch (error) {
+      app.debug(`Cannot register as a resource provider ${error}`);
+    }
+  }
+
+  function registerAsCustomerGarminBusinessResourcesProvider() {
+    try {
+      app.registerResourceProvider({
+        type: 'ac_Business',
+        methods: {
+          listResources: (params) => { 
+            app.debug(`Incoming request to list note resources`)
+            return new Promise((resolve, reject) => {
+              reject(new Error('Still testing'))
+            })
+          },
+          getResource: (id, property) => { 
+            throw(new Error('Not implemented!'))
+          },
+          setResource: (id, value) => { 
+            throw(new Error('Not implemented!'))
+          },
+          deleteResource: (id) => { 
+            throw(new Error('Not implemented!'))
+          }
+        }
+      });
+    } catch (error) {
+      app.debug(`Cannot register as a resource provider ${error}`);
+    }
+  }
+
+  function registerAsCustomerGarminInletResourcesProvider() {
+    try {
+      app.registerResourceProvider({
+        type: 'ac_Inlet',
+        methods: {
+          listResources: (params) => { 
+            app.debug(`Incoming request to list note resources`)
+            return new Promise((resolve, reject) => {
+              reject(new Error('Still testing'))
+            })
+          },
+          getResource: (id, property) => { 
+            throw(new Error('Not implemented!'))
+          },
+          setResource: (id, value) => { 
+            throw(new Error('Not implemented!'))
+          },
+          deleteResource: (id) => { 
+            throw(new Error('Not implemented!'))
+          }
+        }
+      });
+    } catch (error) {
+      app.debug(`Cannot register as a resource provider ${error}`);
+    }
+  }
+
+  function registerAsCustomerGarminBridgeResourcesProvider() {
+    try {
+      app.registerResourceProvider({
+        type: 'ac_Bridge',
+        methods: {
+          listResources: (params) => { 
+            app.debug(`Incoming request to list note resources`)
+            return new Promise((resolve, reject) => {
+              reject(new Error('Still testing'))
+            })
+          },
+          getResource: (id, property) => { 
+            throw(new Error('Not implemented!'))
+          },
+          setResource: (id, value) => { 
+            throw(new Error('Not implemented!'))
+          },
+          deleteResource: (id) => { 
+            throw(new Error('Not implemented!'))
+          }
+        }
+      });
+    } catch (error) {
+      app.debug(`Cannot register as a resource provider ${error}`);
+    }
+  }
+
+  function registerAsCustomerGarminLockResourcesProvider() {
+    try {
+      app.registerResourceProvider({
+        type: 'ac_Lock',
+        methods: {
+          listResources: (params) => { 
+            app.debug(`Incoming request to list note resources`)
+            return new Promise((resolve, reject) => {
+              reject(new Error('Still testing'))
+            })
+          },
+          getResource: (id, property) => { 
+            throw(new Error('Not implemented!'))
+          },
+          setResource: (id, value) => { 
+            throw(new Error('Not implemented!'))
+          },
+          deleteResource: (id) => { 
+            throw(new Error('Not implemented!'))
+          }
+        }
+      });
+    } catch (error) {
+      app.debug(`Cannot register as a resource provider ${error}`);
+    }
+  }
+
+  function registerAsCustomerGarminDamResourcesProvider() {
+    try {
+      app.registerResourceProvider({
+        type: 'ac_Dam',
+        methods: {
+          listResources: (params) => { 
+            app.debug(`Incoming request to list note resources`)
+            return new Promise((resolve, reject) => {
+              reject(new Error('Still testing'))
+            })
+          },
+          getResource: (id, property) => { 
+            throw(new Error('Not implemented!'))
+          },
+          setResource: (id, value) => { 
+            throw(new Error('Not implemented!'))
+          },
+          deleteResource: (id) => { 
+            throw(new Error('Not implemented!'))
+          }
+        }
+      });
+    } catch (error) {
+      app.debug(`Cannot register as a resource provider ${error}`);
+    }
+  }
+
+  function registerAsCustomerGarminFerryResourcesProvider() {
+    try {
+      app.registerResourceProvider({
+        type: 'ac_Ferry',
+        methods: {
+          listResources: (params) => { 
+            app.debug(`Incoming request to list note resources`)
+            return new Promise((resolve, reject) => {
+              reject(new Error('Still testing'))
+            })
+          },
+          getResource: (id, property) => { 
+            throw(new Error('Not implemented!'))
+          },
+          setResource: (id, value) => { 
+            throw(new Error('Not implemented!'))
+          },
+          deleteResource: (id) => { 
+            throw(new Error('Not implemented!'))
+          }
+        }
+      });
+    } catch (error) {
+      app.debug(`Cannot register as a resource provider ${error}`);
+    }
+  }
+
+  function registerAsCustomerGarminAirportResourcesProvider() {
+    try {
+      app.registerResourceProvider({
+        type: 'ac_Airport',
+        methods: {
+          listResources: (params) => { 
+            app.debug(`Incoming request to list note resources`)
+            return new Promise((resolve, reject) => {
+              reject(new Error('Still testing'))
+            })
+          },
+          getResource: (id, property) => { 
+            throw(new Error('Not implemented!'))
+          },
+          setResource: (id, value) => { 
+            throw(new Error('Not implemented!'))
+          },
+          deleteResource: (id) => { 
+            throw(new Error('Not implemented!'))
+          }
+        }
+      });
+    } catch (error) {
+      app.debug(`Cannot register as a resource provider ${error}`);
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -13,18 +13,22 @@
  * limitations under the License.
  */
 
+//import { ResourceProvider } from '@signalk/server-api'
+// const { ResourceProvider } = require('@signalk/server-api');
+
 const request = require('request');
 const poiKey = 'pointsOfInterest.activeCaptain';
-userAgent = 'Signal K ActiveCaptain Plugin';
+const userAgent = 'Signal K ActiveCaptain Plugin';
 const checkEveryNMinutes = 15;
 
 module.exports = function(app) {
-  var plugin = {};
-  var pois = {};
 
-  plugin.id = "signalk-activecaptain";
-  plugin.name = "ActiveCaptain";
-  plugin.description = "Publishes ActiveCaptain Points of Interest";
+  const plugin = {
+    id: "signalk-activecaptain",
+    name: "ActiveCaptain",
+    description: "Publishes ActiveCaptain Points of Interest" 
+  };
+  var pois = {};
 
   plugin.start = function(options) {
     // Position data is not immediately available, delay it
@@ -35,6 +39,35 @@ module.exports = function(app) {
     setInterval( function() {
       checkAndPublishPois();
     }, checkEveryNMinutes * 60 * 1000);
+
+    // Register as a resource provider
+    try {
+      app.registerResourceProvider({
+        type: 'waypoints',
+        methods: {
+          listResources: (params) => { 
+            app.debug(`List`)
+            return new Promise((resolve, reject) => {
+              reject(new Error('Still testing'))
+            })
+          },
+          getResource: (id, property) => { 
+            app.debug(`Get`)
+            return new Promise((resolve, reject) => {
+              reject(new Error('Still testing'))
+            })
+          },
+          setResource: (id, value) => { 
+            throw(new Error('Not implemented!'))
+          },
+          deleteResource: (id) => { 
+            throw(new Error('Not implemented!'))
+          }
+        }
+      });
+    } catch (error) {
+      app.debug(`Cannot register as a resource provider ${error}`);
+    }
   }
 
   plugin.stop =  function() {
@@ -44,6 +77,11 @@ module.exports = function(app) {
     type: 'object',
     required: [],
     properties: {
+      resources: {
+        type: 'boolean',
+        title: 'Also publish activecaptain points of interest as note resources using the resource API',
+        default: true
+      }
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ module.exports = function(app) {
       registerAsNoteResourcesProvider();
     }
     if(options.garminResources) {
-      registerAsCustomGarminResourcesProvider();
+      registerAsCustomResourcesProviders();
     }
   }
 
@@ -102,387 +102,40 @@ module.exports = function(app) {
     }
   }
 
-  function registerAsCustomGarminResourcesProvider() {
-    registerAsCustomerGarminUnknownResourcesProvider();
-    registerAsCustomerGarminAnchorageResourcesProvider();
-    registerAsCustomerGarminHazardResourcesProvider();
-    registerAsCustomerGarminMarinaResourcesProvider();
-    registerAsCustomerGarminLocalKnowledgeResourcesProvider();
-    registerAsCustomerGarminNavigationalResourcesProvider();
-    registerAsCustomerGarminBoatRampResourcesProvider();
-    registerAsCustomerGarminBusinessResourcesProvider();
-    registerAsCustomerGarminInletResourcesProvider();
-    registerAsCustomerGarminBridgeResourcesProvider();
-    registerAsCustomerGarminLockResourcesProvider();
-    registerAsCustomerGarminDamResourcesProvider();
-    registerAsCustomerGarminFerryResourcesProvider();
-    registerAsCustomerGarminAirportResourcesProvider();
+  function registerAsCustomResourcesProviders() {
+    registerAsCustomResourcesProvider('ac_Unknown');
+    registerAsCustomResourcesProvider('ac_Anchorage');
+    registerAsCustomResourcesProvider('ac_Hazard');
+    registerAsCustomResourcesProvider('ac_Marina');
+    registerAsCustomResourcesProvider('ac_LocalKnowledge');
+    registerAsCustomResourcesProvider('ac_Navigational');
+    registerAsCustomResourcesProvider('ac_BoatRamp');
+    registerAsCustomResourcesProvider('ac_Business');
+    registerAsCustomResourcesProvider('ac_Inlet');
+    registerAsCustomResourcesProvider('ac_Lock');
+    registerAsCustomResourcesProvider('ac_Dam');
+    registerAsCustomResourcesProvider('ac_Ferry');
+    registerAsCustomResourcesProvider('ac_Airport');
   }
 
-  function registerAsCustomerGarminUnknownResourcesProvider() {
+  var customResources = {};
+
+  function registerAsCustomResourcesProvider(type) {
     try {
       app.registerResourceProvider({
-        type: 'ac_Unknown',
+        type: type,
         methods: {
           listResources: (params) => { 
-            app.debug(`Incoming request to list note resources`)
+            app.debug(`Incoming request to list ActiveCaptain ${type} resources`)
             return new Promise((resolve, reject) => {
-              reject(new Error('Still testing'))
+              resolve(customResources[type])
             })
           },
           getResource: (id, property) => { 
-            throw(new Error('Not implemented!'))
-          },
-          setResource: (id, value) => { 
-            throw(new Error('Not implemented!'))
-          },
-          deleteResource: (id) => { 
-            throw(new Error('Not implemented!'))
-          }
-        }
-      });
-    } catch (error) {
-      app.debug(`Cannot register as a resource provider ${error}`);
-    }
-  }
-
-  function registerAsCustomerGarminAnchorageResourcesProvider() {
-    try {
-      app.registerResourceProvider({
-        type: 'ac_Anchorage',
-        methods: {
-          listResources: (params) => { 
-            app.debug(`Incoming request to list note resources`)
+            app.debug(`Incoming request to get ActiveCaptain ${type} resource`)
             return new Promise((resolve, reject) => {
-              reject(new Error('Still testing'))
+              resolve(customResources[type][id])
             })
-          },
-          getResource: (id, property) => { 
-            throw(new Error('Not implemented!'))
-          },
-          setResource: (id, value) => { 
-            throw(new Error('Not implemented!'))
-          },
-          deleteResource: (id) => { 
-            throw(new Error('Not implemented!'))
-          }
-        }
-      });
-    } catch (error) {
-      app.debug(`Cannot register as a resource provider ${error}`);
-    }
-  }
-
-  function registerAsCustomerGarminHazardResourcesProvider() {
-    try {
-      app.registerResourceProvider({
-        type: 'ac_Hazard',
-        methods: {
-          listResources: (params) => { 
-            app.debug(`Incoming request to list note resources`)
-            return new Promise((resolve, reject) => {
-              reject(new Error('Still testing'))
-            })
-          },
-          getResource: (id, property) => { 
-            throw(new Error('Not implemented!'))
-          },
-          setResource: (id, value) => { 
-            throw(new Error('Not implemented!'))
-          },
-          deleteResource: (id) => { 
-            throw(new Error('Not implemented!'))
-          }
-        }
-      });
-    } catch (error) {
-      app.debug(`Cannot register as a resource provider ${error}`);
-    }
-  }
-
-  function registerAsCustomerGarminMarinaResourcesProvider() {
-    try {
-      app.registerResourceProvider({
-        type: 'ac_Marina',
-        methods: {
-          listResources: (params) => { 
-            app.debug(`Incoming request to list note resources`)
-            return new Promise((resolve, reject) => {
-              reject(new Error('Still testing'))
-            })
-          },
-          getResource: (id, property) => { 
-            throw(new Error('Not implemented!'))
-          },
-          setResource: (id, value) => { 
-            throw(new Error('Not implemented!'))
-          },
-          deleteResource: (id) => { 
-            throw(new Error('Not implemented!'))
-          }
-        }
-      });
-    } catch (error) {
-      app.debug(`Cannot register as a resource provider ${error}`);
-    }
-  }
-
-  function registerAsCustomerGarminLocalKnowledgeResourcesProvider() {
-    try {
-      app.registerResourceProvider({
-        type: 'ac_LocalKnowledge',
-        methods: {
-          listResources: (params) => { 
-            app.debug(`Incoming request to list note resources`)
-            return new Promise((resolve, reject) => {
-              reject(new Error('Still testing'))
-            })
-          },
-          getResource: (id, property) => { 
-            throw(new Error('Not implemented!'))
-          },
-          setResource: (id, value) => { 
-            throw(new Error('Not implemented!'))
-          },
-          deleteResource: (id) => { 
-            throw(new Error('Not implemented!'))
-          }
-        }
-      });
-    } catch (error) {
-      app.debug(`Cannot register as a resource provider ${error}`);
-    }
-  }
-
-  function registerAsCustomerGarminNavigationalResourcesProvider() {
-    try {
-      app.registerResourceProvider({
-        type: 'ac_Navigational',
-        methods: {
-          listResources: (params) => { 
-            app.debug(`Incoming request to list note resources`)
-            return new Promise((resolve, reject) => {
-              reject(new Error('Still testing'))
-            })
-          },
-          getResource: (id, property) => { 
-            throw(new Error('Not implemented!'))
-          },
-          setResource: (id, value) => { 
-            throw(new Error('Not implemented!'))
-          },
-          deleteResource: (id) => { 
-            throw(new Error('Not implemented!'))
-          }
-        }
-      });
-    } catch (error) {
-      app.debug(`Cannot register as a resource provider ${error}`);
-    }
-  }
-
-  function registerAsCustomerGarminBoatRampResourcesProvider() {
-    try {
-      app.registerResourceProvider({
-        type: 'sc_BoatRamp',
-        methods: {
-          listResources: (params) => { 
-            app.debug(`Incoming request to list note resources`)
-            return new Promise((resolve, reject) => {
-              reject(new Error('Still testing'))
-            })
-          },
-          getResource: (id, property) => { 
-            throw(new Error('Not implemented!'))
-          },
-          setResource: (id, value) => { 
-            throw(new Error('Not implemented!'))
-          },
-          deleteResource: (id) => { 
-            throw(new Error('Not implemented!'))
-          }
-        }
-      });
-    } catch (error) {
-      app.debug(`Cannot register as a resource provider ${error}`);
-    }
-  }
-
-  function registerAsCustomerGarminBusinessResourcesProvider() {
-    try {
-      app.registerResourceProvider({
-        type: 'ac_Business',
-        methods: {
-          listResources: (params) => { 
-            app.debug(`Incoming request to list note resources`)
-            return new Promise((resolve, reject) => {
-              reject(new Error('Still testing'))
-            })
-          },
-          getResource: (id, property) => { 
-            throw(new Error('Not implemented!'))
-          },
-          setResource: (id, value) => { 
-            throw(new Error('Not implemented!'))
-          },
-          deleteResource: (id) => { 
-            throw(new Error('Not implemented!'))
-          }
-        }
-      });
-    } catch (error) {
-      app.debug(`Cannot register as a resource provider ${error}`);
-    }
-  }
-
-  function registerAsCustomerGarminInletResourcesProvider() {
-    try {
-      app.registerResourceProvider({
-        type: 'ac_Inlet',
-        methods: {
-          listResources: (params) => { 
-            app.debug(`Incoming request to list note resources`)
-            return new Promise((resolve, reject) => {
-              reject(new Error('Still testing'))
-            })
-          },
-          getResource: (id, property) => { 
-            throw(new Error('Not implemented!'))
-          },
-          setResource: (id, value) => { 
-            throw(new Error('Not implemented!'))
-          },
-          deleteResource: (id) => { 
-            throw(new Error('Not implemented!'))
-          }
-        }
-      });
-    } catch (error) {
-      app.debug(`Cannot register as a resource provider ${error}`);
-    }
-  }
-
-  function registerAsCustomerGarminBridgeResourcesProvider() {
-    try {
-      app.registerResourceProvider({
-        type: 'ac_Bridge',
-        methods: {
-          listResources: (params) => { 
-            app.debug(`Incoming request to list note resources`)
-            return new Promise((resolve, reject) => {
-              reject(new Error('Still testing'))
-            })
-          },
-          getResource: (id, property) => { 
-            throw(new Error('Not implemented!'))
-          },
-          setResource: (id, value) => { 
-            throw(new Error('Not implemented!'))
-          },
-          deleteResource: (id) => { 
-            throw(new Error('Not implemented!'))
-          }
-        }
-      });
-    } catch (error) {
-      app.debug(`Cannot register as a resource provider ${error}`);
-    }
-  }
-
-  function registerAsCustomerGarminLockResourcesProvider() {
-    try {
-      app.registerResourceProvider({
-        type: 'ac_Lock',
-        methods: {
-          listResources: (params) => { 
-            app.debug(`Incoming request to list note resources`)
-            return new Promise((resolve, reject) => {
-              reject(new Error('Still testing'))
-            })
-          },
-          getResource: (id, property) => { 
-            throw(new Error('Not implemented!'))
-          },
-          setResource: (id, value) => { 
-            throw(new Error('Not implemented!'))
-          },
-          deleteResource: (id) => { 
-            throw(new Error('Not implemented!'))
-          }
-        }
-      });
-    } catch (error) {
-      app.debug(`Cannot register as a resource provider ${error}`);
-    }
-  }
-
-  function registerAsCustomerGarminDamResourcesProvider() {
-    try {
-      app.registerResourceProvider({
-        type: 'ac_Dam',
-        methods: {
-          listResources: (params) => { 
-            app.debug(`Incoming request to list note resources`)
-            return new Promise((resolve, reject) => {
-              reject(new Error('Still testing'))
-            })
-          },
-          getResource: (id, property) => { 
-            throw(new Error('Not implemented!'))
-          },
-          setResource: (id, value) => { 
-            throw(new Error('Not implemented!'))
-          },
-          deleteResource: (id) => { 
-            throw(new Error('Not implemented!'))
-          }
-        }
-      });
-    } catch (error) {
-      app.debug(`Cannot register as a resource provider ${error}`);
-    }
-  }
-
-  function registerAsCustomerGarminFerryResourcesProvider() {
-    try {
-      app.registerResourceProvider({
-        type: 'ac_Ferry',
-        methods: {
-          listResources: (params) => { 
-            app.debug(`Incoming request to list note resources`)
-            return new Promise((resolve, reject) => {
-              reject(new Error('Still testing'))
-            })
-          },
-          getResource: (id, property) => { 
-            throw(new Error('Not implemented!'))
-          },
-          setResource: (id, value) => { 
-            throw(new Error('Not implemented!'))
-          },
-          deleteResource: (id) => { 
-            throw(new Error('Not implemented!'))
-          }
-        }
-      });
-    } catch (error) {
-      app.debug(`Cannot register as a resource provider ${error}`);
-    }
-  }
-
-  function registerAsCustomerGarminAirportResourcesProvider() {
-    try {
-      app.registerResourceProvider({
-        type: 'ac_Airport',
-        methods: {
-          listResources: (params) => { 
-            app.debug(`Incoming request to list note resources`)
-            return new Promise((resolve, reject) => {
-              reject(new Error('Still testing'))
-            })
-          },
-          getResource: (id, property) => { 
-            throw(new Error('Not implemented!'))
           },
           setResource: (id, value) => { 
             throw(new Error('Not implemented!'))
@@ -618,6 +271,11 @@ module.exports = function(app) {
           group: data.pointOfInterest.poiType,
           url: `https://activecaptain.garmin.com/en-US/pois/${poi.id}`
         }
+
+	if(!(`ac_${data.pointOfInterest.poiType}` in customResources)) {
+          customResources[`ac_${data.pointOfInterest.poiType}`] = {};
+        }
+        customResources[`ac_${data.pointOfInterest.poiType}`][poi.id] = data;
 
         app.debug(`Published details for POI ${poi.id}`);
       } else {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "Ilker Temir",
   "license": "Apache-2.0",
   "dependencies": {
-    "request": "^2.88.0"
+    "request": "^2.88.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This is an extension that optionally enables the plugin to publish the ActiveCaptain POIs using the resources API. The result of this is that the data becomes easily consumable by other applications such as the Freeboard chartplotter.

Option 1 publishes the POIs as the built in "notes" resource type, and the result of this is that Freeboard (and other consumers) will see the POIs on the map and are able to query the data.
<img width="1028" alt="image" src="https://github.com/user-attachments/assets/87f04777-369e-443a-9360-4f1384dc42a7">

Option 2 publishes the raw POIs as custom resources according to their type directly from ActiveCaptain. This is illustrated here:
```
curl -XGET "localhost:3000/signalk/v2/api/resources/ac_Lock/68093" | jq
{
  "pointOfInterest": {
    "dateLastModified": "2014-08-07T11:34:21",
    "id": 68093,
    "mapLocation": {
      "latitude": 46.75516272316218,
      "longitude": 4.505402798320954
    },
    "name": "Lock #1 - Canal du Centre",
    "poiType": "Lock",
    "notes": [
      {
        "field": "PoiNotes",
        "value": "Pk 48.8\rVertical drop 2.34m"
      }
    ]
  }
}
```

**IMPORTANT**
Due to the issue reported [here](https://github.com/SignalK/freeboard-sk/issues/200) with Freeboard, this plugin will cause trouble with existing functionality. DO NOT publish this update until the issue has been fixed in freeboard-sk. 